### PR TITLE
Allow Git branch configuration

### DIFF
--- a/charts/openhab/Chart.yaml
+++ b/charts/openhab/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openhab
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.3
+version: 1.1.0
 appVersion: 2.5.9
 icon: https://avatars3.githubusercontent.com/u/1007353?s=200&v=4
 home: https://charts.itstoni.com

--- a/charts/openhab/templates/statefulset.yaml
+++ b/charts/openhab/templates/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
             - name: GIT_SYNC_REPO
               value: "{{ .Values.gitConfig.repoUrl }}"
             - name: GIT_SYNC_BRANCH
-              value: "master"
+              value: {{ .Values.gitConfig.branch | quote }}
             - name: GIT_SYNC_DEPTH
               value: "1"
             - name: GIT_SYNC_ROOT

--- a/charts/openhab/values.yaml
+++ b/charts/openhab/values.yaml
@@ -108,5 +108,6 @@ environment:
 gitConfig:
   enabled: false
   repoUrl: ""
+  branch: master
   # Define ssh private key if your repo is private
   # secretName: git-credentials


### PR DESCRIPTION
This changes adds the ability to select a branch other than "master" for Git sync. The default is "master" to provide backwards compatibility.